### PR TITLE
Fix keyword typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "javascript",
     "npm",
-    "pupetteer",
+    "puppeteer",
     "node"
   ],
   "author": "André Bittencourt",


### PR DESCRIPTION
## Summary
- fix spelling of `puppeteer` keyword in package.json